### PR TITLE
DailyCheck 생성하는 과정 변경

### DIFF
--- a/src/main/java/com/tdl/devist/config/TodoJobConfiguration.java
+++ b/src/main/java/com/tdl/devist/config/TodoJobConfiguration.java
@@ -33,7 +33,7 @@ public class TodoJobConfiguration {
     public Step creatingDailyChecksStep() {
         return stepBuilderFactory.get("creatingDailyChecksStep")
                 .tasklet((contribution, chunkContext) -> {
-                    todoService.checkAndUpdateTodos();
+                    todoService.renewTodos();
 
                     return RepeatStatus.FINISHED;
                 })

--- a/src/main/java/com/tdl/devist/controller/TodoController.java
+++ b/src/main/java/com/tdl/devist/controller/TodoController.java
@@ -72,6 +72,7 @@ public class TodoController {
     @RequestMapping(value = "/{id}/do", method = RequestMethod.POST)
     public @ResponseBody String doTodo(@PathVariable int id, @RequestParam boolean isDone) {
         todoService.setTodoIsDone(id, isDone);
+        todoService.updateDoneRate(id);
         return "ok";
     }
 

--- a/src/main/java/com/tdl/devist/model/DailyCheck.java
+++ b/src/main/java/com/tdl/devist/model/DailyCheck.java
@@ -13,7 +13,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class DailyCheck {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
     private LocalDate planedDate;
     private boolean isDone;

--- a/src/main/java/com/tdl/devist/model/Todo.java
+++ b/src/main/java/com/tdl/devist/model/Todo.java
@@ -64,12 +64,4 @@ public class Todo {
         int dayOfWeek = LocalDate.now().getDayOfWeek().getValue();
         return (repeatDay & (1 << (dayOfWeek - 1))) > 0;
     }
-
-    public void updateDoneRate() {
-        int totalCount = dailyChecks.size();
-        double doneCount = totalCount * doneRate / 100;
-        if (isDone) doneCount++;
-
-        doneRate = doneCount / (totalCount + 1) * 100;
-    }
 }

--- a/src/main/java/com/tdl/devist/repository/DailyCheckRepository.java
+++ b/src/main/java/com/tdl/devist/repository/DailyCheckRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 public interface DailyCheckRepository extends JpaRepository<DailyCheck, Integer> {
     List<DailyCheck> findByPlanedDate(LocalDate planedDate);
+    List<DailyCheck> findByTodoAndPlanedDate(Todo todo, LocalDate planedDate);
     List<DailyCheck> findByTodo(Todo todo);
     List<DailyCheck> findByTodoAndIsDone(Todo todo, boolean isDone);
 }

--- a/src/main/java/com/tdl/devist/repository/DailyCheckRepository.java
+++ b/src/main/java/com/tdl/devist/repository/DailyCheckRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 public interface DailyCheckRepository extends JpaRepository<DailyCheck, Integer> {
     List<DailyCheck> findByPlanedDate(LocalDate planedDate);
     List<DailyCheck> findByTodo(Todo todo);
+    List<DailyCheck> findByTodoAndIsDone(Todo todo, boolean isDone);
 }

--- a/src/main/java/com/tdl/devist/service/DailyCheckService.java
+++ b/src/main/java/com/tdl/devist/service/DailyCheckService.java
@@ -20,9 +20,8 @@ public class DailyCheckService {
     void createDailyCheckByTodo(Todo todo) {
         DailyCheck dailyCheck = new DailyCheck();
         dailyCheck.setTodo(todo);
-        dailyCheck.setDone(todo.isDone());
-        // 매일 자정에 실행 되면 현재 날짜는 실행과 동시에 하루가 지나게 되므로 이 전날의 날짜를 넣어준다.
-        dailyCheck.setPlanedDate(LocalDate.now().minusDays(1));
+        dailyCheck.setDone(false);
+        dailyCheck.setPlanedDate(LocalDate.now());
         dailyCheckRepository.save(dailyCheck);
     }
 
@@ -32,5 +31,11 @@ public class DailyCheckService {
 
     int getDoneCountByTodo(Todo todo) {
         return dailyCheckRepository.findByTodoAndIsDone(todo, true).size();
+    }
+
+    void setTodayCheckDone(Todo todo, boolean isDone) {
+        DailyCheck dailyCheck = dailyCheckRepository.findByTodoAndPlanedDate(todo, LocalDate.now()).get(0);
+        dailyCheck.setDone(isDone);
+        dailyCheckRepository.save(dailyCheck);
     }
 }

--- a/src/main/java/com/tdl/devist/service/DailyCheckService.java
+++ b/src/main/java/com/tdl/devist/service/DailyCheckService.java
@@ -25,4 +25,12 @@ public class DailyCheckService {
         dailyCheck.setPlanedDate(LocalDate.now().minusDays(1));
         dailyCheckRepository.save(dailyCheck);
     }
+
+    int getTotalCountByTodo(Todo todo) {
+        return dailyCheckRepository.findByTodo(todo).size();
+    }
+
+    int getDoneCountByTodo(Todo todo) {
+        return dailyCheckRepository.findByTodoAndIsDone(todo, true).size();
+    }
 }

--- a/src/main/java/com/tdl/devist/service/TodoService.java
+++ b/src/main/java/com/tdl/devist/service/TodoService.java
@@ -45,21 +45,30 @@ public class TodoService {
         return todoRepository.findAll();
     }
 
-    public void setTodoIsDone(int todo_id, boolean isDone) {
-        Todo todo = todoRepository.getOne(todo_id);
-        todo.setDone(isDone);
-        todoRepository.save(todo);
-    }
-
     public void checkAndUpdateTodos() {
         for (Todo todo: todoRepository.findAll()) {
             // Todo: 같은 날에 두번 실행되지 않도록 하는 예외처리 추가하기.
             if (todo.isTodaysTodo()) {
-                todo.updateDoneRate();
                 dailyCheckService.createDailyCheckByTodo(todo);
                 todo.setDone(false);
                 todoRepository.save(todo);
             }
         }
+    }
+
+    public void setTodoIsDone(int todoId, boolean isDone) {
+        Todo todo = todoRepository.getOne(todoId);
+        todo.setDone(isDone);
+        todoRepository.save(todo);
+    }
+
+    public void updateDoneRate(int todoId) {
+        Todo todo = todoRepository.getOne(todoId);
+        int totalCount = dailyCheckService.getTotalCountByTodo(todo);
+        int doneCount = dailyCheckService.getDoneCountByTodo(todo);
+
+        todo.setDoneRate((double)doneCount / totalCount * 100.00);
+        System.out.println(todo.getDoneRate());
+        todoRepository.save(todo);
     }
 }

--- a/src/main/java/com/tdl/devist/service/TodoService.java
+++ b/src/main/java/com/tdl/devist/service/TodoService.java
@@ -45,7 +45,7 @@ public class TodoService {
         return todoRepository.findAll();
     }
 
-    public void checkAndUpdateTodos() {
+    public void renewTodos() {
         for (Todo todo: todoRepository.findAll()) {
             // Todo: 같은 날에 두번 실행되지 않도록 하는 예외처리 추가하기.
             if (todo.isTodaysTodo()) {
@@ -58,7 +58,9 @@ public class TodoService {
 
     public void setTodoIsDone(int todoId, boolean isDone) {
         Todo todo = todoRepository.getOne(todoId);
+        if (!todo.isTodaysTodo()) return; // Todo: Error 처리
         todo.setDone(isDone);
+        dailyCheckService.setTodayCheckDone(todo, isDone);
         todoRepository.save(todo);
     }
 
@@ -68,7 +70,6 @@ public class TodoService {
         int doneCount = dailyCheckService.getDoneCountByTodo(todo);
 
         todo.setDoneRate((double)doneCount / totalCount * 100.00);
-        System.out.println(todo.getDoneRate());
         todoRepository.save(todo);
     }
 }

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -7,9 +7,12 @@ insert into todos (todo_id, title, description, created_time, done_rate, is_done
 insert into todos (todo_id, title, description, created_time, done_rate, is_done, repeat_day, username) values (1, 'spring 동영상 강의 보기', 'youtube spring 검색. www.youtube.com', '2019-01-02 11:20:14.000', 100.00, 0, 66, 'cjh5414');
 insert into todos (todo_id, title, description, created_time, done_rate, is_done, repeat_day, username) values (2, '블로그 쓰기', '수요일 마다', '2019-01-02 11:20:14.000', 100.00, 0, 4, 'cjh5414');
 insert into todos (todo_id, title, description, created_time, done_rate, is_done, repeat_day, username) values (3, '완료된 할 일 1', '매일 하는 일인데 테스트 할라고 완료 시킴', '2019-01-02 11:20:14.000', 100.00, 1, 127, 'cjh5414');
-insert into todos (todo_id, title, description, created_time, done_rate, is_done, repeat_day, username) values (4, 'Daily check 4개 가지고 있는 할 일', '4개 중에 2개만 완료.', '2018-01-02 11:20:14.000', 50.00, 1, 127, 'cjh5414');
---
+insert into todos (todo_id, title, description, created_time, done_rate, is_done, repeat_day, username) values (4, 'Daily check 4개 가지고 있는 할 일', '4개 중에 2개만 완료.', '2018-01-02 11:20:14.000', 40.00, 1, 127, 'cjh5414');
+
 insert into daily_checks (id, planed_date, is_done, todo_id) values (0, '2018-12-20', 0, 4);
 insert into daily_checks (id, planed_date, is_done, todo_id) values (1, '2018-12-21', 0, 4);
 insert into daily_checks (id, planed_date, is_done, todo_id) values (2, '2018-12-22', 1, 4);
 insert into daily_checks (id, planed_date, is_done, todo_id) values (3, '2018-12-23', 1, 4);
+insert into daily_checks (id, planed_date, is_done, todo_id) values (4, '2019-1-1', 0, 4);
+
+insert into daily_checks (id, planed_date, is_done, todo_id) values (5, '2019-1-1', 0, 0);

--- a/src/test/java/com/tdl/devist/controller/HomeControllerTests.java
+++ b/src/test/java/com/tdl/devist/controller/HomeControllerTests.java
@@ -45,14 +45,14 @@ public class HomeControllerTests {
                 .andExpect(status().isOk())
                 .andExpect(view().name("user_home"))
                 .andExpect(content().string(is(not(containsString("알고리즘 문제 풀기")))))
-                .andExpect(content().string(is(not(containsString("spring 동영상 강의 보기")))));
+                .andExpect(content().string(is(not(containsString("매일 하는 일인데 테스트 할라고 완료 시킴")))));
 
         mockMvc.perform(get("/")
                 .with(user("cjh5414").password("1234").roles("USER")))
                 .andExpect(status().isOk())
                 .andExpect(view().name("user_home"))
                 .andExpect(content().string(containsString("알고리즘 문제 풀기")))
-                .andExpect(content().string(containsString("spring 동영상 강의 보기")));
+                .andExpect(content().string(containsString("매일 하는 일인데 테스트 할라고 완료 시킴")));
     }
 }
 

--- a/src/test/java/com/tdl/devist/controller/TodoControllerTests.java
+++ b/src/test/java/com/tdl/devist/controller/TodoControllerTests.java
@@ -1,5 +1,6 @@
 package com.tdl.devist.controller;
 
+import com.tdl.devist.testutils.UtilsForTests;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +29,9 @@ public class TodoControllerTests {
     @Autowired
     private WebApplicationContext context;
     private MockMvc mockMvc;
+
+    @Autowired
+    private UtilsForTests utils;
 
     @Before
     public void setup() {
@@ -64,10 +68,11 @@ public class TodoControllerTests {
 
     @Test
     public void testCheckTodoIsDone() throws Exception {
+        utils.updatePlanedDateToToday(0);
         mockMvc.perform(post("/todo/0/do")
                 .param("isDone", "true")
                 .with(csrf())
-                .with(user("admin").password("1234").roles("ADMIN")))
+                .with(user("cjh5414").password("1234").roles("USER")))
                 .andExpect(status().isOk())
                 .andExpect(content().string("ok"));
     }

--- a/src/test/java/com/tdl/devist/model/UserTest.java
+++ b/src/test/java/com/tdl/devist/model/UserTest.java
@@ -57,7 +57,7 @@ public class UserTest {
 
         int todoSize = 1;
         switch (LocalDate.now().getDayOfWeek().getValue()) {
-            case 1:
+            case 2:
             case 3:
             case 7:
                 todoSize = 2;

--- a/src/test/java/com/tdl/devist/service/DailyCheckServiceTests.java
+++ b/src/test/java/com/tdl/devist/service/DailyCheckServiceTests.java
@@ -31,18 +31,9 @@ public class DailyCheckServiceTests {
     @Test
     @Transactional
     public void TestCreateDailyCheckByTodo() {
-        Todo notDoneTodo = todoRepository.getOne(0);
-
-        dailyCheckService.createDailyCheckByTodo(notDoneTodo);
-        DailyCheck dailyCheck = dailyCheckRepository.findByTodo(notDoneTodo).get(0);
+        Todo todo = todoRepository.getOne(4);
+        dailyCheckService.createDailyCheckByTodo(todo);
+        DailyCheck dailyCheck = dailyCheckRepository.findByTodoAndPlanedDate(todo, LocalDate.now()).get(0);
         Assert.assertFalse(dailyCheck.isDone());
-        Assert.assertEquals(LocalDate.now().minusDays(1), dailyCheck.getPlanedDate());
-
-        Todo doneTodo = todoRepository.getOne(3);
-
-        dailyCheckService.createDailyCheckByTodo(doneTodo);
-        dailyCheck = dailyCheckRepository.findByTodo(doneTodo).get(0);
-        Assert.assertTrue(dailyCheck.isDone());
-        Assert.assertEquals(LocalDate.now().minusDays(1), dailyCheck.getPlanedDate());
     }
 }

--- a/src/test/java/com/tdl/devist/service/DailyCheckServiceTests.java
+++ b/src/test/java/com/tdl/devist/service/DailyCheckServiceTests.java
@@ -14,7 +14,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import javax.transaction.Transactional;
 import java.time.LocalDate;
-import java.util.List;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest

--- a/src/test/java/com/tdl/devist/service/TodoServiceTests.java
+++ b/src/test/java/com/tdl/devist/service/TodoServiceTests.java
@@ -88,7 +88,7 @@ public class TodoServiceTests {
 
     @Test
     @Transactional
-    public void testSetTodoIsDone() {
+    public void testSetTodoIsDoneWhenUserDo() {
         final int TODO_ID = 0;
         Todo todo = todoRepository.getOne(TODO_ID);
         Assert.assertFalse(todo.isDone());
@@ -126,13 +126,21 @@ public class TodoServiceTests {
 
     @Test
     @Transactional
-    public void updateDoneRateAfterPlanedDate() {
+    public void testUpdateDoneRateWhenUserDo() {
         Todo todo = todoRepository.getOne(4);
         Assert.assertEquals(50.00, todo.getDoneRate(), 00.01);
 
-        todoService.checkAndUpdateTodos();
+        todoService.setTodoIsDone(4, false);
+        todoService.updateDoneRate(4);
 
         todo = todoRepository.getOne(4);
-        Assert.assertEquals(60.00, todo.getDoneRate(), 00.01);
+        Assert.assertEquals(40.00, todo.getDoneRate(), 00.01);
+
+        todoService.setTodoIsDone(4, true);
+        todoService.updateDoneRate(4);
+
+        todo = todoRepository.getOne(4);
+        Assert.assertEquals(50.00, todo.getDoneRate(), 00.01);
+
     }
 }

--- a/src/test/java/com/tdl/devist/service/TodoServiceTests.java
+++ b/src/test/java/com/tdl/devist/service/TodoServiceTests.java
@@ -6,6 +6,7 @@ import com.tdl.devist.model.Todo;
 import com.tdl.devist.model.User;
 import com.tdl.devist.repository.DailyCheckRepository;
 import com.tdl.devist.repository.TodoRepository;
+import com.tdl.devist.testutils.UtilsForTests;
 import org.junit.Assert;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -19,6 +20,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import javax.transaction.Transactional;
 import java.time.LocalDate;
 import java.util.List;
+
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -37,6 +39,9 @@ public class TodoServiceTests {
 
     @Autowired
     private DailyCheckRepository dailyCheckRepository;
+
+    @Autowired
+    private UtilsForTests utils;
 
     private final String TEST_USER_NAME = "dbadmin";
     private final String TEST_TODO_TITLE = "Todo 테스트하기";
@@ -89,6 +94,8 @@ public class TodoServiceTests {
     @Test
     @Transactional
     public void testSetTodoIsDoneWhenUserDo() {
+        utils.updatePlanedDateToToday(0);
+
         final int TODO_ID = 0;
         Todo todo = todoRepository.getOne(TODO_ID);
         Assert.assertFalse(todo.isDone());
@@ -104,43 +111,66 @@ public class TodoServiceTests {
 
     @Test
     @Transactional
-    public void testCheckTodosAfterPlanedDate() {
-        Todo doneTodo = todoRepository.getOne(3);
-        Assert.assertTrue(doneTodo.isDone());
-        Assert.assertEquals(0, dailyCheckRepository.findByTodo(doneTodo).size());
+    public void testUpdateTodoIsDoneAfterRenewing() {
+        todoService.renewTodos();
 
-        int todayTodoCount = 0;
-        for (Todo todo: todoRepository.findAll())
+        List<Todo> todoList = todoRepository.findAll();
+        for (Todo todo : todoList)
             if (todo.isTodaysTodo())
-                todayTodoCount++;
+                Assert.assertFalse(todo.isDone());
+    }
 
-        todoService.checkAndUpdateTodos();
+    @Test
+    @Transactional
+    public void testCreateDailyCheckAfterRenewing() {
+        Todo doneTodo = todoRepository.getOne(3);
+        int beforeDailyCheckCount = dailyCheckRepository.findByTodo(doneTodo).size();
+
+        todoService.renewTodos();
 
         doneTodo = todoRepository.getOne(3);
-        Assert.assertFalse(doneTodo.isDone());
 
-        LocalDate planedDate = LocalDate.now().minusDays(1);
-        List<DailyCheck> todayDailyCheckList = dailyCheckRepository.findByPlanedDate(planedDate);
-        Assert.assertEquals(todayTodoCount, todayDailyCheckList.size());
+        Assert.assertEquals(beforeDailyCheckCount + 1, dailyCheckRepository.findByTodo(doneTodo).size());
+
+        List<DailyCheck> newDailyCheckList = dailyCheckRepository.findByTodoAndPlanedDate(doneTodo, LocalDate.now());
+        Assert.assertEquals(1, newDailyCheckList.size());
+    }
+
+    @Test
+    @Transactional
+    public void TestCreatedDailyCheckCountWhenTodosRreRenewed() {
+        List<Todo> todoList = todoRepository.findAll();
+        int createdDailyChecksCount = 0;
+
+        for (Todo todo : todoList)
+            if (todo.isTodaysTodo())
+                createdDailyChecksCount++;
+
+        todoService.renewTodos();
+
+        List<DailyCheck> dailyChecklist = dailyCheckRepository.findByPlanedDate(LocalDate.now());
+        Assert.assertEquals(createdDailyChecksCount, dailyChecklist.size());
     }
 
     @Test
     @Transactional
     public void testUpdateDoneRateWhenUserDo() {
+        utils.updatePlanedDateToToday(4);
+
         Todo todo = todoRepository.getOne(4);
-        Assert.assertEquals(50.00, todo.getDoneRate(), 00.01);
-
-        todoService.setTodoIsDone(4, false);
-        todoService.updateDoneRate(4);
-
-        todo = todoRepository.getOne(4);
         Assert.assertEquals(40.00, todo.getDoneRate(), 00.01);
 
         todoService.setTodoIsDone(4, true);
         todoService.updateDoneRate(4);
 
         todo = todoRepository.getOne(4);
-        Assert.assertEquals(50.00, todo.getDoneRate(), 00.01);
+        Assert.assertEquals(60.00, todo.getDoneRate(), 00.01);
+
+        todoService.setTodoIsDone(4, false);
+        todoService.updateDoneRate(4);
+
+        todo = todoRepository.getOne(4);
+        Assert.assertEquals(40.00, todo.getDoneRate(), 00.01);
 
     }
 }

--- a/src/test/java/com/tdl/devist/testutils/UtilsForTests.java
+++ b/src/test/java/com/tdl/devist/testutils/UtilsForTests.java
@@ -1,0 +1,29 @@
+package com.tdl.devist.testutils;
+
+import com.tdl.devist.model.DailyCheck;
+import com.tdl.devist.model.Todo;
+import com.tdl.devist.repository.DailyCheckRepository;
+import com.tdl.devist.repository.TodoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.transaction.Transactional;
+import java.time.LocalDate;
+
+@Component
+public class UtilsForTests {
+    @Autowired
+    private DailyCheckRepository dailyCheckRepository;
+
+    @Autowired
+    private TodoRepository todoRepository;
+
+    // todo의 dailyCheck 중에 planedDate가 2019-1-1 로 설정 된 것을 오늘 날짜로 변경한다.
+    @Transactional
+    public void updatePlanedDateToToday(int todoId) {
+        Todo todo = todoRepository.getOne(todoId);
+        DailyCheck dailyCheck = dailyCheckRepository.findByTodoAndPlanedDate(todo, LocalDate.of(2019, 1, 1)).get(0);
+        dailyCheck.setPlanedDate(LocalDate.now());
+        dailyCheckRepository.save(dailyCheck);
+    }
+}


### PR DESCRIPTION
- 기존의 방법인 자정에 해당 날짜 전날의 DailyCheck를 생성하는 방법을 오늘 날짜의 DailyCheck를 생성하여 관리, 사용하는 방법으로 변경. 
> 이유는 DoneRate을 업데이트하기 쉽고, 추후에 Todo의 isDone 필드를 제거하고 최신 날짜의 latestDailyCheck를 새로 추가하여 관리할 예정.

- 이에 따라서 doneRate을 갱신하는 과정도 변경.
- 기타 수정하면서 테스트 코드에서 발생한 에러 해결.

- #35 