### PR TITLE
Fix repeatDay convert algorithm error

### DIFF
--- a/src/main/java/com/tdl/devist/model/Todo.java
+++ b/src/main/java/com/tdl/devist/model/Todo.java
@@ -62,7 +62,7 @@ public class Todo {
 
     public void convertRepeatDayByteToBooleanArr() {
         for (int i = 0; i < repeatCheckbox.length; i++) {
-            repeatCheckbox[repeatCheckbox.length - 1 - i] = ((repeatDay << i) & 1) == 1;
+            repeatCheckbox[repeatCheckbox.length - 1 - i] = ((repeatDay >> i) & 1) == 1;
         }
     }
 

--- a/src/test/java/com/tdl/devist/model/TodoTest.java
+++ b/src/test/java/com/tdl/devist/model/TodoTest.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.context.annotation.Profile;
 
-import javax.transaction.Transactional;
 import java.util.Arrays;
 
 
@@ -17,17 +16,17 @@ public class TodoTest {
     @Test
     public void 변환테스트_byte에서_booleanArr() {
         Todo todo = generateTestTodoInstance();
-        todo.setRepeatDay((byte) 1);
+        todo.setRepeatDay((byte) 65);
         todo.convertRepeatDayByteToBooleanArr();
-        Assert.assertEquals(Arrays.toString(new boolean[]{false, false, false, false, false, false, true}), Arrays.toString(todo.getRepeatCheckbox()));
+        Assert.assertEquals(Arrays.toString(new boolean[]{true, false, false, false, false, false, true}), Arrays.toString(todo.getRepeatCheckbox()));
     }
 
     @Test
     public void 변환테스트_booleanArr에서_byte() {
         Todo todo = generateTestTodoInstance();
-        todo.setRepeatCheckbox(new boolean[]{false, false, false, false, false, false, true});
+        todo.setRepeatCheckbox(new boolean[]{true, false, false, false, false, false, true});
         todo.convertRepeatDayBooleanArrToByte();
-        Assert.assertEquals(1, todo.getRepeatDay());
+        Assert.assertEquals(65, todo.getRepeatDay());
     }
 
     private User generateTestUserInstance() {


### PR DESCRIPTION
repeatDay(`byte`)를 repeatCheckbox(`boolean[]`)으로 변환하는 알고리즘의 오류를 수정했습니다.

우연히 통과되던 테스트 코드를 수정했습니다.

(issue #19 에서 파생됨)